### PR TITLE
Will use logicalDestPort only in FlowClassifier

### DIFF
--- a/nsfc-plugin/bnd.bnd
+++ b/nsfc-plugin/bnd.bnd
@@ -1,4 +1,6 @@
 
+Bundle-SymbolicName: sdn-controller-nsfc-plugin
+
 Import-Package: javassist.util.proxy,*
 
 #Exporting entities and utils so that PaxExam in OSGiIntegrationTest works.

--- a/nsfc-plugin/src/main/java/org/osc/controller/nsfc/api/NeutronSfcSdnControllerApi.java
+++ b/nsfc-plugin/src/main/java/org/osc/controller/nsfc/api/NeutronSfcSdnControllerApi.java
@@ -32,8 +32,6 @@ import org.osc.sdk.controller.api.SdnControllerApi;
 import org.osc.sdk.controller.api.SdnRedirectionApi;
 import org.osc.sdk.controller.element.VirtualizationConnectorElement;
 import org.osgi.service.component.annotations.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Component(configurationPid = "org.osc.nsfc.SdnController",
     property = { PLUGIN_NAME + "=Neutron-sfc",
@@ -45,8 +43,6 @@ import org.slf4j.LoggerFactory;
                  SUPPORT_PORT_GROUP + ":Boolean=false",
                  SUPPORT_NEUTRON_SFC + ":Boolean=true"})
 public class NeutronSfcSdnControllerApi implements SdnControllerApi {
-
-    private static final Logger LOG = LoggerFactory.getLogger(NeutronSfcSdnControllerApi.class);
 
     private static final String VERSION = "0.1";
     private static final String NAME = "Neutron-sfc";

--- a/nsfc-plugin/src/main/java/org/osc/controller/nsfc/api/NeutronSfcSdnRedirectionApi.java
+++ b/nsfc-plugin/src/main/java/org/osc/controller/nsfc/api/NeutronSfcSdnRedirectionApi.java
@@ -241,9 +241,7 @@ public class NeutronSfcSdnRedirectionApi implements SdnRedirectionApi {
         checkArgument(portChain != null,
                       "Cannot find %s by id: %s!", "Service Function Chain", inspectionPortElement.getElementId());
 
-        ServiceFunctionChainElement sfcElement = this.utils.fetchSFCWithChildDepends(portChain);
-
-        FlowClassifier flowClassifier = this.utils.buildFlowClassifier(inspectedPortElement.getElementId(), sfcElement);
+        FlowClassifier flowClassifier = this.utils.buildFlowClassifier(inspectedPortElement.getElementId());
 
         flowClassifier = this.osCalls.createFlowClassifier(flowClassifier);
         portChain.getFlowClassifiers().add(flowClassifier.getId());

--- a/nsfc-plugin/src/main/java/org/osc/controller/nsfc/utils/ArgumentCheckUtil.java
+++ b/nsfc-plugin/src/main/java/org/osc/controller/nsfc/utils/ArgumentCheckUtil.java
@@ -48,6 +48,4 @@ public class ArgumentCheckUtil {
            throw new IllegalArgumentException(msg);
        }
    }
-
-
 }

--- a/nsfc-plugin/src/main/java/org/osc/controller/nsfc/utils/OsCalls.java
+++ b/nsfc-plugin/src/main/java/org/osc/controller/nsfc/utils/OsCalls.java
@@ -40,13 +40,8 @@ public class OsCalls {
 
    public FlowClassifier createFlowClassifier(FlowClassifier flowClassifier) {
        checkArgument(flowClassifier != null, "null passed for %s !", "Flow Classifier");
-       String ip = flowClassifier.getDestinationIpPrefix();
 
-       if (ip != null && !ip.endsWith("/32")) {
-           ip += "/32";
-       }
-
-       flowClassifier = flowClassifier.toBuilder().id(null).destinationIpPrefix(ip).build();
+       flowClassifier = flowClassifier.toBuilder().id(null).build();
        return this.osClient.sfc().flowclassifiers().create(flowClassifier);
    }
 

--- a/nsfc-plugin/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
+++ b/nsfc-plugin/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
@@ -19,16 +19,14 @@ package org.osc.controller.nsfc.utils;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toSet;
-import static org.osc.controller.nsfc.api.NeutronSfcSdnRedirectionApi.KEY_HOOK_ID;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.openstack4j.api.Builders;
@@ -37,7 +35,6 @@ import org.openstack4j.model.network.ext.FlowClassifier;
 import org.openstack4j.model.network.ext.PortChain;
 import org.openstack4j.model.network.ext.PortPair;
 import org.openstack4j.model.network.ext.PortPairGroup;
-import org.openstack4j.model.network.options.PortListOptions;
 import org.osc.controller.nsfc.entities.NetworkElementImpl;
 import org.osc.controller.nsfc.entities.PortPairElement;
 import org.osc.controller.nsfc.entities.PortPairGroupElement;
@@ -141,20 +138,7 @@ public class RedirectionApiUtils {
     }
 
     public Port fetchProtectedPort(FlowClassifier flowClassifier) {
-        String ip = flowClassifier.getDestinationIpPrefix();
-
-        if (ip != null && ip.matches("^.*/32$")) {
-            ip = ip.substring(0, ip.length() - 3);
-        }
-
-        PortListOptions options = PortListOptions.create().tenantId(flowClassifier.getTenantId());
-        options.getOptions().put("ip_address", ip);
-
-        List<? extends Port> ports = this.osCalls.listPorts();
-        Port port = ports.stream().filter(p -> p.getProfile() != null
-                                            && flowClassifier.getId().equals(p.getProfile().get(KEY_HOOK_ID)))
-                          .findFirst().orElse(null);
-        return port;
+        return this.osCalls.getPort(flowClassifier.getLogicalDestinationPort());
     }
 
     /**
@@ -202,71 +186,13 @@ public class RedirectionApiUtils {
         return pcOpt.orElse(null);
     }
 
-    /**
-     * Assumes argument is not null
-     */
-    public FlowClassifier fetchInspHookByInspectedPort(NetworkElement inspected) {
-        LOG.info("Finding Flow Classifiers for inspected port {}", inspected);
-
-        Port inspectedPort  = this.osCalls.getPort(inspected.getElementId());
-
-        if (inspectedPort == null) {
-            throw new IllegalArgumentException(String.format("Flow Classifier %s does not exist!", inspected.getElementId()));
-        }
-
-        if (inspectedPort.getProfile() == null || inspectedPort.getProfile().get(KEY_HOOK_ID) == null) {
-            LOG.warn("No Flow Classifier for inspected port {}", inspected.getElementId());
-            return null;
-        }
-
-        String hookId = (String) inspectedPort.getProfile().get(KEY_HOOK_ID);
-        FlowClassifier flowClassifier = this.osCalls.getFlowClassifier(hookId);
-
-        if (flowClassifier == null) {
-            setHookOnPort(inspectedPort.getId(), null);
-            LOG.warn("Flow Classifier {} for inspected port {} no longer exists!",
-                     hookId, inspected.getElementId());
-            return null;
-        }
-
-        return flowClassifier;
-    }
-
-    /**
-     *
-     * @param port
-     * @param hookId set to null to un-hook
-     * @return modified port
-     */
-    public void setHookOnPort(String portId, String hookId) {
-        Port port = this.osCalls.getPort(portId);
-
-        if (port == null) {
-            return;
-        }
-
-        Map<String, Object> profile = new HashMap<>();
-        if (hookId == null) {
-            profile.remove(KEY_HOOK_ID);
-        } else {
-            profile.put(KEY_HOOK_ID, hookId);
-        }
-
-        port = port.toBuilder().profile(profile).build();
-        this.osCalls.updatePort(port);
-    }
-
-    public FlowClassifier buildFlowClassifier(String inspectedPortIp, ServiceFunctionChainElement sfcElement) {
+    public FlowClassifier buildFlowClassifier(String inspectedPortId, ServiceFunctionChainElement sfcElement) {
         FlowClassifier flowClassifier;
-        String sourcePortId = sfcElement.getPortPairGroups().get(0).getPortPairs().get(0).getIngressPort().getElementId();
-        int nGroups = sfcElement.getPortPairGroups().size();
-        String destPortId = sfcElement.getPortPairGroups().get(nGroups - 1).getPortPairs().get(0).getEgressPort().getElementId();
 
         flowClassifier = Builders.flowClassifier()
                              .description("Flow Classifier created by OSC")
-                             .destinationIpPrefix(inspectedPortIp)
-                             .logicalSourcePort(sourcePortId)
-                             .logicalDestinationPort(destPortId)
+                             .name("OSCFlowClassifier-" + UUID.randomUUID().toString().substring(0, 8))
+                             .logicalDestinationPort(inspectedPortId)
                              .build();
         return flowClassifier;
     }

--- a/nsfc-plugin/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
+++ b/nsfc-plugin/src/main/java/org/osc/controller/nsfc/utils/RedirectionApiUtils.java
@@ -186,7 +186,7 @@ public class RedirectionApiUtils {
         return pcOpt.orElse(null);
     }
 
-    public FlowClassifier buildFlowClassifier(String inspectedPortId, ServiceFunctionChainElement sfcElement) {
+    public FlowClassifier buildFlowClassifier(String inspectedPortId) {
         FlowClassifier flowClassifier;
 
         flowClassifier = Builders.flowClassifier()

--- a/nsfc-plugin/src/test/java/org/osc/controller/nsfc/LiveEnvIntegrationTest.java
+++ b/nsfc-plugin/src/test/java/org/osc/controller/nsfc/LiveEnvIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.*;
 import static org.osc.sdk.controller.FailurePolicyType.NA;
 import static org.osc.sdk.controller.TagEncapsulationType.VLAN;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -32,10 +31,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
-import org.openstack4j.api.Builders;
 import org.openstack4j.api.OSClient.OSClientV3;
 import org.openstack4j.api.client.IOSClientBuilder.V3;
-import org.openstack4j.api.exceptions.ClientResponseException;
 import org.openstack4j.model.common.Identifier;
 import org.openstack4j.model.network.Port;
 import org.openstack4j.model.network.ext.FlowClassifier;
@@ -221,38 +218,6 @@ public class LiveEnvIntegrationTest {
         // Assert.
         assertNull(noSuchHook);
         assertTrue(this.redirApi instanceof NeutronSfcSdnRedirectionApi);
-    }
-
-    // The following test proves that create calls are not idempotent.
-    // It results in ClientResponseException {message=Port Pair
-    // with ingress port <SOME_UUID> and
-    // egress port <SOME_UUID> is already used by another Port Pair
-    // <SOME_UUID>, status=400, status-code=BAD_REQUEST}
-//        @Test
-    public void testIdempotent() throws Exception {
-
-        PortPair pp = Builders.portPair().ingressId(INGRESS0_ID).egressId(EGRESS0_ID).build();
-
-        pp = this.osClient.sfc().portpairs().create(pp);
-
-        pp = pp.toBuilder().id(null).projectId(null).build();
-        this.exception.expect(ClientResponseException.class);
-        pp = this.osClient.sfc().portpairs().create(pp);
-    }
-
-//    @Test
-    public void testIdempotentPPG() throws Exception {
-
-        PortPair pp = Builders.portPair().ingressId(INGRESS0_ID).egressId(EGRESS0_ID).build();
-
-        pp = this.osClient.sfc().portpairs().create(pp);
-
-        PortPairGroup ppg = Builders.portPairGroup().portPairs(Arrays.asList(pp.getId())).build();
-        ppg = this.osClient.sfc().portpairgroups().create(ppg);
-        ppg = ppg.toBuilder().id(null).projectId(null).build();
-
-        this.exception.expect(ClientResponseException.class);
-        this.osClient.sfc().portpairgroups().create(ppg);
     }
 
 //    @Test

--- a/nsfc-plugin/src/test/java/org/osc/controller/nsfc/LiveEnvIntegrationTest.java
+++ b/nsfc-plugin/src/test/java/org/osc/controller/nsfc/LiveEnvIntegrationTest.java
@@ -1,0 +1,403 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.controller.nsfc;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+import static org.osc.sdk.controller.FailurePolicyType.NA;
+import static org.osc.sdk.controller.TagEncapsulationType.VLAN;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.openstack4j.api.Builders;
+import org.openstack4j.api.OSClient.OSClientV3;
+import org.openstack4j.api.client.IOSClientBuilder.V3;
+import org.openstack4j.api.exceptions.ClientResponseException;
+import org.openstack4j.model.common.Identifier;
+import org.openstack4j.model.network.Port;
+import org.openstack4j.model.network.ext.FlowClassifier;
+import org.openstack4j.model.network.ext.PortChain;
+import org.openstack4j.model.network.ext.PortPair;
+import org.openstack4j.model.network.ext.PortPairGroup;
+import org.openstack4j.openstack.OSFactory;
+import org.osc.controller.nsfc.api.NeutronSfcSdnControllerApi;
+import org.osc.controller.nsfc.api.NeutronSfcSdnRedirectionApi;
+import org.osc.controller.nsfc.entities.NetworkElementImpl;
+import org.osc.controller.nsfc.entities.PortPairElement;
+import org.osc.controller.nsfc.entities.ServiceFunctionChainElement;
+import org.osc.sdk.controller.api.SdnControllerApi;
+import org.osc.sdk.controller.api.SdnRedirectionApi;
+import org.osc.sdk.controller.element.Element;
+import org.osc.sdk.controller.element.InspectionHookElement;
+import org.osc.sdk.controller.element.NetworkElement;
+import org.osc.sdk.controller.element.VirtualizationConnectorElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LiveEnvIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LiveEnvIntegrationTest.class);
+
+    private static final String DOMAIN_NAME = "default";
+    private static final String PASSWORD = "admin123";
+    private static final String USERNAME = "admin";
+    private static final String TENANT = "admin";
+    private static final String TEST_CONTROLLER_IP = "10.3.243.183";
+
+    private static final String INGRESS0_ID = "ec1ca134-db9c-4fdc-8964-2b18851eca1b";
+    private static final String EGRESS0_ID = "ec1ca134-db9c-4fdc-8964-2b18851eca1b";
+
+    private static final String INGRESS0_IP = "172.16.3.14";
+    private static final String EGRESS0_IP = "172.16.3.14";
+
+    private static final String INGRESS0_MAC = "fa:16:3e:cb:44:2d";
+    private static final String EGRESS0_MAC = "fa:16:3e:cb:44:2d";
+
+    private static final String INGRESS1_ID = "6c47e906-f305-4ba0-9b7f-2b375c166b0d";
+    private static final String EGRESS1_ID = "6c47e906-f305-4ba0-9b7f-2b375c166b0d";
+
+    private static final String INGRESS1_IP = "172.16.1.5";
+    private static final String EGRESS1_IP = "172.16.1.5";
+
+    private static final String INGRESS1_MAC = "fa:16:3e:d3:84:7e";
+    private static final String EGRESS1_MAC = "fa:16:3e:d3:84:7e";
+
+    private static final String INSPECTED_ID = "11e5dd85-b1f7-422d-a822-181351b22aef";
+    private static final String INSPECTED_IP = "172.16.3.8";
+    private static final String INSPECTED_MAC = "fa:16:3e:ca:37:38";
+
+    // just for verifying stuff
+    private OSClientV3 osClient;
+    private NetworkElementImpl ingressElement0;
+    private NetworkElementImpl egressElement0;
+    private PortPairElement inspectionPortElement0;
+    private NetworkElementImpl ingressElement1;
+    private NetworkElementImpl egressElement1;
+    private PortPairElement inspectionPortElement1;
+
+    SdnControllerApi api;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private SdnRedirectionApi redirApi;
+
+    private static final VirtualizationConnectorElement VC =
+            new VirtualizationConnectorElement() {
+
+                @Override
+                public String getName() {
+                    return "dummy";
+                }
+
+                @Override
+                public String getControllerIpAddress() {
+                    return "dummy";                }
+
+                @Override
+                public String getControllerUsername() {
+                    return "dummy";                }
+
+                @Override
+                public String getControllerPassword() {
+                    return "dummy";                }
+
+                @Override
+                public boolean isControllerHttps() {
+                    return false;
+                }
+
+                @Override
+                public String getProviderIpAddress() {
+                    return TEST_CONTROLLER_IP;       }
+
+                @Override
+                public String getProviderUsername() {
+                    return USERNAME;                }
+
+                @Override
+                public String getProviderPassword() {
+                    return PASSWORD;                }
+
+                @Override
+                public String getProviderAdminTenantName() {
+                    return TENANT;                }
+
+                @Override
+                public String getProviderAdminDomainId() {
+                    return DOMAIN_NAME;                }
+
+                @Override
+                public boolean isProviderHttps() {
+                    return false;
+                }
+
+                @Override
+                public Map<String, String> getProviderAttributes() {
+                    return null;
+                }
+
+                @Override
+                public SSLContext getSslContext() {
+                    return null;
+                }
+
+                @Override
+                public TrustManager[] getTruststoreManager() throws Exception {
+                    return null;
+                }
+    };
+
+    @Before
+    public void setup() {
+        String domain = VC.getProviderAdminDomainId();
+        String username = VC.getProviderUsername();
+        String password = VC.getProviderPassword();
+        String tenantName = VC.getProviderAdminTenantName();
+
+        V3 v3 = OSFactory.builderV3()
+                .endpoint("http://" + VC.getProviderIpAddress() + ":5000/v3")
+                .credentials(username, password, Identifier.byName(domain))
+                .scopeToProject(Identifier.byName(tenantName), Identifier.byName(domain));
+
+        this.osClient = v3.authenticate();
+        this.api =  new NeutronSfcSdnControllerApi();
+
+        // On control node, use 'drivers = dummy' in /etc/neutron/neutron.conf. That's under [ovs] section.
+        // You should have prepared an opentack with sfc and two servers on management network!
+        // Normally, we want to use 'drivers = sfc' but that one is buggy as of 3/15/18.
+        // See https://docs.openstack.org/networking-sfc/latest/install/index.html
+
+        this.ingressElement0 = new NetworkElementImpl(INGRESS0_ID, asList(INGRESS0_MAC),
+                                                                    asList(INGRESS0_IP), null);
+        this.egressElement0 = new NetworkElementImpl(EGRESS0_ID, asList(EGRESS0_MAC),
+                                                                  asList(EGRESS0_IP), null);
+        this.inspectionPortElement0 = new PortPairElement(null, null, this.ingressElement0, this.egressElement0);
+
+        this.ingressElement1 = new NetworkElementImpl(INGRESS1_ID, asList(INGRESS1_MAC),
+                                                                    asList(INGRESS1_IP), null);
+        this.egressElement1 = new NetworkElementImpl(EGRESS1_ID, asList(EGRESS1_MAC),
+                       asList(EGRESS1_IP), null);
+        this.inspectionPortElement1 = new PortPairElement(null, null, this.ingressElement1, this.egressElement1);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (this.redirApi != null) {
+            this.redirApi.close();
+        }
+        cleanAllOnOpenstack();
+    }
+
+//  @Test
+    public void verifyApiResponds() throws Exception {
+        // Act.
+        this.redirApi = this.api.createRedirectionApi(VC, "DummyRegion");
+        InspectionHookElement noSuchHook = this.redirApi.getInspectionHook("No shuch hook");
+
+        // Assert.
+        assertNull(noSuchHook);
+        assertTrue(this.redirApi instanceof NeutronSfcSdnRedirectionApi);
+    }
+
+    // The following test proves that create calls are not idempotent.
+    // It results in ClientResponseException {message=Port Pair
+    // with ingress port <SOME_UUID> and
+    // egress port <SOME_UUID> is already used by another Port Pair
+    // <SOME_UUID>, status=400, status-code=BAD_REQUEST}
+//        @Test
+    public void testIdempotent() throws Exception {
+
+        PortPair pp = Builders.portPair().ingressId(INGRESS0_ID).egressId(EGRESS0_ID).build();
+
+        pp = this.osClient.sfc().portpairs().create(pp);
+
+        pp = pp.toBuilder().id(null).projectId(null).build();
+        this.exception.expect(ClientResponseException.class);
+        pp = this.osClient.sfc().portpairs().create(pp);
+    }
+
+//    @Test
+    public void testIdempotentPPG() throws Exception {
+
+        PortPair pp = Builders.portPair().ingressId(INGRESS0_ID).egressId(EGRESS0_ID).build();
+
+        pp = this.osClient.sfc().portpairs().create(pp);
+
+        PortPairGroup ppg = Builders.portPairGroup().portPairs(Arrays.asList(pp.getId())).build();
+        ppg = this.osClient.sfc().portpairgroups().create(ppg);
+        ppg = ppg.toBuilder().id(null).projectId(null).build();
+
+        this.exception.expect(ClientResponseException.class);
+        this.osClient.sfc().portpairgroups().create(ppg);
+    }
+
+//    @Test
+    public void testPortPairsWorkflow() throws Exception {
+        this.redirApi = this.api.createRedirectionApi(VC, "DummyRegion");
+
+        // TEST CALL
+        Element result0 = this.redirApi.registerInspectionPort(this.inspectionPortElement0);
+
+        assertNotNull(result0);
+        LOG.debug("Success registering inspection port {} (Actual class {})", result0.getElementId(), result0.getClass());
+        this.inspectionPortElement0 = (PortPairElement) result0;
+
+        assertPortPairGroupIsOk(this.inspectionPortElement0);
+        assertIngressEgressOk(this.inspectionPortElement0);
+
+        // same parent
+        this.inspectionPortElement1.setPortPairGroup(this.inspectionPortElement0.getPortPairGroup());
+
+        // TEST CALL
+        Element result1 = this.redirApi.registerInspectionPort(this.inspectionPortElement1);
+
+        assertNotNull(result1);
+        LOG.debug("Success registering inspection port {} (Actual class {})", result1.getElementId(), result1.getClass());
+        this.inspectionPortElement1 = (PortPairElement) result1;
+
+        assertEquals(this.inspectionPortElement0.getParentId(), this.inspectionPortElement1.getParentId());
+        assertPortPairGroupIsOk(this.inspectionPortElement1);
+        assertIngressEgressOk(this.inspectionPortElement0);
+
+        // TEST CALL
+        this.redirApi.removeInspectionPort(this.inspectionPortElement0);
+
+        assertNull(this.osClient.sfc().portpairs().get(this.inspectionPortElement0.getElementId()));
+        assertNotNull(this.osClient.sfc().portpairs().get(this.inspectionPortElement1.getElementId()));
+        assertNotNull(this.osClient.sfc().portpairgroups().get(this.inspectionPortElement0.getParentId()));
+
+        // TEST CALL
+        this.redirApi.removeInspectionPort(this.inspectionPortElement1);
+
+        assertNull(this.osClient.sfc().portpairs().get(this.inspectionPortElement1.getElementId()));
+        assertNull(this.osClient.sfc().portpairgroups().get(this.inspectionPortElement1.getParentId()));
+    }
+
+//    @Test
+    public void testInspectionHooksWorkflow_BothPairsInSamePPG() throws Exception {
+        this.redirApi = this.api.createRedirectionApi(VC, "DummyRegion");
+
+        Element result0 = this.redirApi.registerInspectionPort(this.inspectionPortElement0);
+        this.inspectionPortElement0 = (PortPairElement) result0;
+
+        // same parent
+        this.inspectionPortElement1.setPortPairGroup(this.inspectionPortElement0.getPortPairGroup());
+
+        Element result1 = this.redirApi.registerInspectionPort(this.inspectionPortElement1);
+        this.inspectionPortElement1 = (PortPairElement) result1;
+
+        // TEST CALL
+        NetworkElement ne = this.redirApi.registerNetworkElement(asList(this.inspectionPortElement0.getPortPairGroup()));
+        ServiceFunctionChainElement sfc = (ServiceFunctionChainElement) ne;
+
+        NetworkElementImpl inspected = new NetworkElementImpl(INSPECTED_ID, asList(INSPECTED_MAC),
+                                                                  asList(INSPECTED_IP), null);
+
+        // TEST CALL
+        String hookId = this.redirApi.installInspectionHook(inspected, sfc, 0L, VLAN, 0L, NA);
+
+        assertNotNull(hookId);
+
+        // TEST CALL
+        InspectionHookElement ih = this.redirApi.getInspectionHook(hookId);
+
+        assertNotNull(ih);
+
+        Port inspectedPortCheck = this.osClient.networking().port().get(INSPECTED_ID);
+        assertNotNull(inspectedPortCheck);
+
+        String sfcId = ih.getInspectionPort().getElementId();
+        assertEquals(sfc.getElementId(), sfcId);
+
+        ServiceFunctionChainElement sfcElementCheck = (ServiceFunctionChainElement) ih.getInspectionPort();
+        assertEquals(sfc.getElementId(), sfcElementCheck.getElementId());
+        assertNotNull(sfcElementCheck.getInspectionHooks());
+        assertEquals(1, sfcElementCheck.getInspectionHooks().size());
+        assertEquals(hookId, sfcElementCheck.getInspectionHooks().iterator().next().getHookId());
+
+        PortChain portChainCheck = this.osClient.sfc().portchains().get(sfcId);
+        assertNotNull(portChainCheck);
+
+        FlowClassifier flowClassifierCheck = this.osClient.sfc().flowclassifiers().get(hookId);
+        assertNotNull(flowClassifierCheck);
+        assertTrue(portChainCheck.getFlowClassifiers().contains(hookId));
+
+        // TEST CALL
+        this.redirApi.removeInspectionHook(hookId);
+
+        assertNull(this.redirApi.getInspectionHook(hookId));
+        assertNull(this.osClient.sfc().flowclassifiers().get(hookId));
+
+        portChainCheck = this.osClient.sfc().portchains().get(sfcId);
+        assertFalse(portChainCheck.getFlowClassifiers() != null
+                          && portChainCheck.getFlowClassifiers().contains(hookId));
+
+        // TEST CALL
+        this.redirApi.deleteNetworkElement(sfc);
+        assertNull(this.osClient.sfc().portchains().get(sfc.getElementId()));
+    }
+
+//    @Test
+    public void cleanAllOnOpenstack() {
+        List<? extends PortChain> portChains = this.osClient.sfc().portchains().list();
+        List<? extends FlowClassifier> flowClassifiers = this.osClient.sfc().flowclassifiers().list();
+        List<? extends PortPairGroup> portPairGroups = this.osClient.sfc().portpairgroups().list();
+        List<? extends PortPair> portPairs = this.osClient.sfc().portpairs().list();
+
+        for (PortChain pc : portChains) {
+            this.osClient.sfc().portchains().delete(pc.getId());
+        }
+        for (FlowClassifier fc : flowClassifiers) {
+            this.osClient.sfc().flowclassifiers().delete(fc.getId());
+        }
+        for (PortPairGroup ppg : portPairGroups) {
+            this.osClient.sfc().portpairgroups().delete(ppg.getId());
+        }
+        for (PortPair pp : portPairs) {
+            this.osClient.sfc().portpairs().delete(pp.getId());
+        }
+
+        assertEquals("Failed clean port chains!", 0, this.osClient.sfc().portchains().list().size());
+        assertEquals("Failed clean flow classifiers!", 0, this.osClient.sfc().flowclassifiers().list().size());
+        assertEquals("Failed clean port pair groups!", 0, this.osClient.sfc().portpairgroups().list().size());
+        assertEquals("Failed clean port pairs!", 0, this.osClient.sfc().portpairs().list().size());
+    }
+
+    private void assertIngressEgressOk(PortPairElement inspectionPortElement) {
+        PortPair portPairCheck = this.osClient.sfc().portpairs().get(inspectionPortElement.getElementId());
+        assertEquals(inspectionPortElement.getEgressPort().getElementId(), portPairCheck.getEgressId());
+        assertEquals(inspectionPortElement.getEgressPort().getElementId(), portPairCheck.getEgressId());
+    }
+
+    private void assertPortPairGroupIsOk(PortPairElement inspectionPortElement) {
+        assertNotNull(inspectionPortElement.getPortPairGroup());
+        PortPairGroup ppgCheck = this.osClient.sfc().portpairgroups().get(inspectionPortElement.getParentId());
+        assertNotNull(ppgCheck);
+        assertNotNull(ppgCheck.getPortPairs());
+        assertTrue(ppgCheck.getPortPairs().contains(inspectionPortElement.getElementId()));
+    }
+}

--- a/nsfc-plugin/src/test/java/org/osc/controller/nsfc/LiveEnvIntegrationTest.java
+++ b/nsfc-plugin/src/test/java/org/osc/controller/nsfc/LiveEnvIntegrationTest.java
@@ -54,6 +54,23 @@ import org.osc.sdk.controller.element.VirtualizationConnectorElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This test is run against live ocata environment. Username and password should work.
+ * The Project (AKA Tenant) should be admin.
+ * INGRESS/EGRESS ID's, MAC's and IP's should correspond to pre-created VM's on
+ * ocata.
+ *
+ * Due to certain issues with networking-sfc plugin and openvswitch, we have to make certain temporary concessions.
+ * We are not really using the ovs driver. On control node, use 'drivers = dummy' in /etc/neutron/neutron.conf.
+ * That's under the [ovs] section.
+ *
+ * On the compute node, comment out the "extensions = sfc" line in
+ * /etc/neutron/plugins/ml2/openvswitch_agent.ini. Effectively, this turns off hte actual
+ * networking_sfc agent and only tests the plugin, making sure the api calls are correct and
+ * in correct sequence.
+ *
+ * See https://docs.openstack.org/networking-sfc/latest/install/index.html
+ */
 public class LiveEnvIntegrationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(LiveEnvIntegrationTest.class);
@@ -182,11 +199,6 @@ public class LiveEnvIntegrationTest {
 
         this.osClient = v3.authenticate();
         this.api =  new NeutronSfcSdnControllerApi();
-
-        // On control node, use 'drivers = dummy' in /etc/neutron/neutron.conf. That's under [ovs] section.
-        // You should have prepared an opentack with sfc and two servers on management network!
-        // Normally, we want to use 'drivers = sfc' but that one is buggy as of 3/15/18.
-        // See https://docs.openstack.org/networking-sfc/latest/install/index.html
 
         this.ingressElement0 = new NetworkElementImpl(INGRESS0_ID, asList(INGRESS0_MAC),
                                                                     asList(INGRESS0_IP), null);

--- a/nsfc-plugin/src/test/java/org/osc/controller/nsfc/NeutronSfcSdnRedirectionApiTest.java
+++ b/nsfc-plugin/src/test/java/org/osc/controller/nsfc/NeutronSfcSdnRedirectionApiTest.java
@@ -113,7 +113,6 @@ public class NeutronSfcSdnRedirectionApiTest extends AbstractNeutronSfcPluginTes
         assertNotNull(foundInspPortElement);
     }
 
-
     @Test
     public void testApi_RegisterInspectionPortWithParentId_Succeeds() throws Exception {
         // Arrange.
@@ -188,8 +187,7 @@ public class NeutronSfcSdnRedirectionApiTest extends AbstractNeutronSfcPluginTes
         assertTrue(portPairGroup.getPortPairs().contains(portPair.getId()));
         assertEquals(portPairGroup.getId(), registeredElement.getParentId());
 
-        InspectionPortElement foundInspectionPort =
-                this.redirApi.getInspectionPort(new PortPairElement(portPair.getId(), null, ingressPortElement, egressPortElement));
+        this.redirApi.getInspectionPort(new PortPairElement(portPair.getId(), null, ingressPortElement, egressPortElement));
 
         assertEquals(inspectionPortElement.getElementId(), portPair.getId());
 
@@ -340,7 +338,6 @@ public class NeutronSfcSdnRedirectionApiTest extends AbstractNeutronSfcPluginTes
         persistPortChainAndSfcElement();
 
         FlowClassifierElement updatedHook = new FlowClassifierElement("non-existing-id", inspected, sfc);
-
 
         this.exception.expect(IllegalArgumentException.class);
         this.exception.expectMessage(StringStartsWith.startsWith("Cannot find Flow Classifier"));
@@ -509,7 +506,6 @@ public class NeutronSfcSdnRedirectionApiTest extends AbstractNeutronSfcPluginTes
         // Act
         this.redirApi.updateNetworkElement(sfcPort, neList);
     }
-
 
     @Test
     public void testApi_UpdateNetworkElementWhenPpgIdIsChainedToSameSfc_VerifySuccessful()

--- a/nsfc-plugin/src/test/java/org/osc/controller/nsfc/OSGiIntegrationTest.java
+++ b/nsfc-plugin/src/test/java/org/osc/controller/nsfc/OSGiIntegrationTest.java
@@ -16,96 +16,26 @@
  *******************************************************************************/
 package org.osc.controller.nsfc;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 import static org.ops4j.pax.exam.CoreOptions.*;
-import static org.osc.sdk.controller.FailurePolicyType.NA;
-import static org.osc.sdk.controller.TagEncapsulationType.VLAN;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 import javax.inject.Inject;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.openstack4j.api.Builders;
-import org.openstack4j.api.OSClient.OSClientV3;
-import org.openstack4j.api.client.IOSClientBuilder.V3;
-import org.openstack4j.api.exceptions.ClientResponseException;
-import org.openstack4j.model.common.Identifier;
-import org.openstack4j.model.network.Port;
-import org.openstack4j.model.network.ext.FlowClassifier;
-import org.openstack4j.model.network.ext.PortChain;
-import org.openstack4j.model.network.ext.PortPair;
-import org.openstack4j.model.network.ext.PortPairGroup;
-import org.openstack4j.openstack.OSFactory;
+import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.ops4j.pax.exam.util.PathUtils;
-import org.osc.controller.nsfc.api.NeutronSfcSdnRedirectionApi;
-import org.osc.controller.nsfc.entities.NetworkElementImpl;
-import org.osc.controller.nsfc.entities.PortPairElement;
-import org.osc.controller.nsfc.entities.ServiceFunctionChainElement;
 import org.osc.sdk.controller.api.SdnControllerApi;
-import org.osc.sdk.controller.api.SdnRedirectionApi;
-import org.osc.sdk.controller.element.Element;
-import org.osc.sdk.controller.element.InspectionHookElement;
-import org.osc.sdk.controller.element.NetworkElement;
-import org.osc.sdk.controller.element.VirtualizationConnectorElement;
 import org.osgi.framework.BundleContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-//@RunWith(PaxExam.class)
-//@ExamReactorStrategy(PerClass.class)
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
 public class OSGiIntegrationTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(OSGiIntegrationTest.class);
-
-    private static final String DOMAIN_NAME = "default";
-    private static final String PASSWORD = "admin123";
-    private static final String USERNAME = "admin";
-    private static final String TENANT = "admin";
-    private static final String TEST_CONTROLLER_IP = "10.3.243.183";
-
-    private static final String INGRESS0_ID = "ec1ca134-db9c-4fdc-8964-2b18851eca1b";
-    private static final String EGRESS0_ID = "ec1ca134-db9c-4fdc-8964-2b18851eca1b";
-//    private static final String EGRESS0_ID = "5686a891-cf7a-4803-a286-e00c70a96995";
-
-    private static final String INGRESS0_IP = "172.16.3.14";
-    private static final String EGRESS0_IP = "172.16.3.14";
-//    private static final String EGRESS0_IP = "172.16.1.4";
-
-    private static final String INGRESS0_MAC = "fa:16:3e:cb:44:2d";
-    private static final String EGRESS0_MAC = "fa:16:3e:cb:44:2d";
-//    private static final String EGRESS0_MAC = "fa:16:3e:66:5b:42";
-
-    private static final String INGRESS1_ID = "6c47e906-f305-4ba0-9b7f-2b375c166b0d";
-    private static final String EGRESS1_ID = "6c47e906-f305-4ba0-9b7f-2b375c166b0d";
-
-    private static final String INGRESS1_IP = "172.16.1.5";
-    private static final String EGRESS1_IP = "172.16.1.5";
-
-    private static final String INGRESS1_MAC = "fa:16:3e:d3:84:7e";
-    private static final String EGRESS1_MAC = "fa:16:3e:d3:84:7e";
-
-    private static final String INSPECTED_ID = "11e5dd85-b1f7-422d-a822-181351b22aef";
-    private static final String INSPECTED_IP = "172.16.3.8";
-    private static final String INSPECTED_MAC = "fa:16:3e:ca:37:38";
-
-    // just for verifying stuff
-    private OSClientV3 osClient;
-    private NetworkElementImpl ingressElement0;
-    private NetworkElementImpl egressElement0;
-    private PortPairElement inspectionPortElement0;
-    private NetworkElementImpl ingressElement1;
-    private NetworkElementImpl egressElement1;
-    private PortPairElement inspectionPortElement1;
 
     @Inject
     BundleContext context;
@@ -115,74 +45,6 @@ public class OSGiIntegrationTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
-
-    private SdnRedirectionApi redirApi;
-
-    private static final VirtualizationConnectorElement VC =
-            new VirtualizationConnectorElement() {
-
-                @Override
-                public String getName() {
-                    return "dummy";
-                }
-
-                @Override
-                public String getControllerIpAddress() {
-                    return "dummy";                }
-
-                @Override
-                public String getControllerUsername() {
-                    return "dummy";                }
-
-                @Override
-                public String getControllerPassword() {
-                    return "dummy";                }
-
-                @Override
-                public boolean isControllerHttps() {
-                    return false;
-                }
-
-                @Override
-                public String getProviderIpAddress() {
-                    return TEST_CONTROLLER_IP;       }
-
-                @Override
-                public String getProviderUsername() {
-                    return USERNAME;                }
-
-                @Override
-                public String getProviderPassword() {
-                    return PASSWORD;                }
-
-                @Override
-                public String getProviderAdminTenantName() {
-                    return TENANT;                }
-
-                @Override
-                public String getProviderAdminDomainId() {
-                    return DOMAIN_NAME;                }
-
-                @Override
-                public boolean isProviderHttps() {
-                    return false;
-                }
-
-                @Override
-                public Map<String, String> getProviderAttributes() {
-                    return null;
-                }
-
-                @Override
-                public SSLContext getSslContext() {
-                    return null;
-                }
-
-                @Override
-                public TrustManager[] getTruststoreManager() throws Exception {
-                    return null;
-                }
-    };
 
     @org.ops4j.pax.exam.Configuration
     public Option[] config() {
@@ -253,232 +115,8 @@ public class OSGiIntegrationTest {
         }
     }
 
-    @Before
-    public void setup() {
-        String domain = VC.getProviderAdminDomainId();
-        String username = VC.getProviderUsername();
-        String password = VC.getProviderPassword();
-        String tenantName = VC.getProviderAdminTenantName();
-
-        V3 v3 = OSFactory.builderV3()
-                .endpoint("http://" + VC.getProviderIpAddress() + ":5000/v3")
-                .credentials(username, password, Identifier.byName(domain))
-                .scopeToProject(Identifier.byName(tenantName), Identifier.byName(domain));
-
-        this.osClient = v3.authenticate();
-
-        // On control node, use 'drivers = dummy' in /etc/neutron/neutron.conf. That's under [ovs] section.
-        // You should have prepared an opentack with sfc and two servers on management network!
-        // Normally, we want to use 'drivers = sfc' but that one is buggy as of 3/15/18.
-        // See https://docs.openstack.org/networking-sfc/latest/install/index.html
-
-        this.ingressElement0 = new NetworkElementImpl(INGRESS0_ID, asList(INGRESS0_MAC),
-                                                                    asList(INGRESS0_IP), null);
-        this.egressElement0 = new NetworkElementImpl(EGRESS0_ID, asList(EGRESS0_MAC),
-                                                                  asList(EGRESS0_IP), null);
-        this.inspectionPortElement0 = new PortPairElement(null, null, this.ingressElement0, this.egressElement0);
-
-        this.ingressElement1 = new NetworkElementImpl(INGRESS1_ID, asList(INGRESS1_MAC),
-                                                                    asList(INGRESS1_IP), null);
-        this.egressElement1 = new NetworkElementImpl(EGRESS1_ID, asList(EGRESS1_MAC),
-                       asList(EGRESS1_IP), null);
-        this.inspectionPortElement1 = new PortPairElement(null, null, this.ingressElement1, this.egressElement1);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        if (this.redirApi != null) {
-            this.redirApi.close();
-        }
-//        cleanAllOnOpenstack();
-    }
-
-//  @Test
+    @Test
     public void verifyApiResponds() throws Exception {
-        // Act.
-        this.redirApi = this.api.createRedirectionApi(VC, "DummyRegion");
-        InspectionHookElement noSuchHook = this.redirApi.getInspectionHook("No shuch hook");
-
-        // Assert.
-        assertNull(noSuchHook);
-        assertTrue(this.redirApi instanceof NeutronSfcSdnRedirectionApi);
-    }
-
-    // The following test proves that create calls are not idempotent.
-    // It results in ClientResponseException {message=Port Pair
-    // with ingress port <SOME_UUID> and
-    // egress port <SOME_UUID> is already used by another Port Pair
-    // <SOME_UUID>, status=400, status-code=BAD_REQUEST}
-    //    @Test
-    public void testIdempotent() throws Exception {
-
-        PortPair pp = Builders.portPair().ingressId(INGRESS0_ID).egressId(EGRESS0_ID).build();
-
-        pp = this.osClient.sfc().portpairs().create(pp);
-
-        pp = pp.toBuilder().id(null).projectId(null).build();
-        this.exception.expect(ClientResponseException.class);
-        pp = this.osClient.sfc().portpairs().create(pp);
-    }
-
-//    @Test
-    public void testIdempotentPPG() throws Exception {
-
-        PortPair pp = Builders.portPair().ingressId(INGRESS0_ID).egressId(EGRESS0_ID).build();
-
-        pp = this.osClient.sfc().portpairs().create(pp);
-
-        PortPairGroup ppg = Builders.portPairGroup().portPairs(Arrays.asList(pp.getId())).build();
-        ppg = this.osClient.sfc().portpairgroups().create(ppg);
-        ppg = ppg.toBuilder().id(null).projectId(null).build();
-
-        this.exception.expect(ClientResponseException.class);
-        this.osClient.sfc().portpairgroups().create(ppg);
-    }
-
-//    @Test
-    public void testPortPairsWorkflow() throws Exception {
-        this.redirApi = this.api.createRedirectionApi(VC, "DummyRegion");
-
-        // TEST CALL
-        Element result0 = this.redirApi.registerInspectionPort(this.inspectionPortElement0);
-
-        assertNotNull(result0);
-        LOG.debug("Success registering inspection port {} (Actual class {})", result0.getElementId(), result0.getClass());
-        this.inspectionPortElement0 = (PortPairElement) result0;
-
-        assertPortPairGroupIsOk(this.inspectionPortElement0);
-        assertIngressEgressOk(this.inspectionPortElement0);
-
-        // same parent
-        this.inspectionPortElement1.setPortPairGroup(this.inspectionPortElement0.getPortPairGroup());
-
-        // TEST CALL
-        Element result1 = this.redirApi.registerInspectionPort(this.inspectionPortElement1);
-
-        assertNotNull(result1);
-        LOG.debug("Success registering inspection port {} (Actual class {})", result1.getElementId(), result1.getClass());
-        this.inspectionPortElement1 = (PortPairElement) result1;
-
-        assertEquals(this.inspectionPortElement0.getParentId(), this.inspectionPortElement1.getParentId());
-        assertPortPairGroupIsOk(this.inspectionPortElement1);
-        assertIngressEgressOk(this.inspectionPortElement0);
-
-        // TEST CALL
-        this.redirApi.removeInspectionPort(this.inspectionPortElement0);
-
-        assertNull(this.osClient.sfc().portpairs().get(this.inspectionPortElement0.getElementId()));
-        assertNotNull(this.osClient.sfc().portpairs().get(this.inspectionPortElement1.getElementId()));
-        assertNotNull(this.osClient.sfc().portpairgroups().get(this.inspectionPortElement0.getParentId()));
-
-        // TEST CALL
-        this.redirApi.removeInspectionPort(this.inspectionPortElement1);
-
-        assertNull(this.osClient.sfc().portpairs().get(this.inspectionPortElement1.getElementId()));
-        assertNull(this.osClient.sfc().portpairgroups().get(this.inspectionPortElement1.getParentId()));
-    }
-
-//    @Test
-    public void testInspectionHooksWorkflow_BothPairsInSamePPG() throws Exception {
-        this.redirApi = this.api.createRedirectionApi(VC, "DummyRegion");
-
-        Element result0 = this.redirApi.registerInspectionPort(this.inspectionPortElement0);
-        this.inspectionPortElement0 = (PortPairElement) result0;
-
-        // same parent
-        this.inspectionPortElement1.setPortPairGroup(this.inspectionPortElement0.getPortPairGroup());
-
-        Element result1 = this.redirApi.registerInspectionPort(this.inspectionPortElement1);
-        this.inspectionPortElement1 = (PortPairElement) result1;
-
-        // TEST CALL
-        NetworkElement ne = this.redirApi.registerNetworkElement(asList(this.inspectionPortElement0.getPortPairGroup()));
-        ServiceFunctionChainElement sfc = (ServiceFunctionChainElement) ne;
-
-        NetworkElementImpl inspected = new NetworkElementImpl(INSPECTED_ID, asList(INSPECTED_MAC),
-                                                                  asList(INSPECTED_IP), null);
-
-        // TEST CALL
-        String hookId = this.redirApi.installInspectionHook(inspected, sfc, 0L, VLAN, 0L, NA);
-
-        assertNotNull(hookId);
-
-        // TEST CALL
-        InspectionHookElement ih = this.redirApi.getInspectionHook(hookId);
-
-        assertNotNull(ih);
-
-        Port inspectedPortCheck = this.osClient.networking().port().get(INSPECTED_ID);
-        assertNotNull(inspectedPortCheck);
-
-        String sfcId = ih.getInspectionPort().getElementId();
-        assertEquals(sfc.getElementId(), sfcId);
-
-        ServiceFunctionChainElement sfcElementCheck = (ServiceFunctionChainElement) ih.getInspectionPort();
-        assertEquals(sfc.getElementId(), sfcElementCheck.getElementId());
-        assertNotNull(sfcElementCheck.getInspectionHooks());
-        assertEquals(1, sfcElementCheck.getInspectionHooks().size());
-        assertEquals(hookId, sfcElementCheck.getInspectionHooks().iterator().next().getHookId());
-
-        PortChain portChainCheck = this.osClient.sfc().portchains().get(sfcId);
-        assertNotNull(portChainCheck);
-
-        FlowClassifier flowClassifierCheck = this.osClient.sfc().flowclassifiers().get(hookId);
-        assertNotNull(flowClassifierCheck);
-        assertTrue(portChainCheck.getFlowClassifiers().contains(hookId));
-
-        // TEST CALL
-        this.redirApi.removeInspectionHook(hookId);
-
-        assertNull(this.redirApi.getInspectionHook(hookId));
-        assertNull(this.osClient.sfc().flowclassifiers().get(hookId));
-
-        portChainCheck = this.osClient.sfc().portchains().get(sfcId);
-        assertFalse(portChainCheck.getFlowClassifiers() != null
-                          && portChainCheck.getFlowClassifiers().contains(hookId));
-
-        // TEST CALL
-        this.redirApi.deleteNetworkElement(sfc);
-        assertNull(this.osClient.sfc().portchains().get(sfc.getElementId()));
-    }
-
-//    @Test
-    public void cleanAllOnOpenstack() {
-        List<? extends PortChain> portChains = this.osClient.sfc().portchains().list();
-        List<? extends FlowClassifier> flowClassifiers = this.osClient.sfc().flowclassifiers().list();
-        List<? extends PortPairGroup> portPairGroups = this.osClient.sfc().portpairgroups().list();
-        List<? extends PortPair> portPairs = this.osClient.sfc().portpairs().list();
-
-        for (PortChain pc : portChains) {
-            this.osClient.sfc().portchains().delete(pc.getId());
-        }
-        for (FlowClassifier fc : flowClassifiers) {
-            this.osClient.sfc().flowclassifiers().delete(fc.getId());
-        }
-        for (PortPairGroup ppg : portPairGroups) {
-            this.osClient.sfc().portpairgroups().delete(ppg.getId());
-        }
-        for (PortPair pp : portPairs) {
-            this.osClient.sfc().portpairs().delete(pp.getId());
-        }
-
-        assertEquals("Failed clean port chains!", 0, this.osClient.sfc().portchains().list().size());
-        assertEquals("Failed clean flow classifiers!", 0, this.osClient.sfc().flowclassifiers().list().size());
-        assertEquals("Failed clean port pair groups!", 0, this.osClient.sfc().portpairgroups().list().size());
-        assertEquals("Failed clean port pairs!", 0, this.osClient.sfc().portpairs().list().size());
-    }
-
-    private void assertIngressEgressOk(PortPairElement inspectionPortElement) {
-        PortPair portPairCheck = this.osClient.sfc().portpairs().get(inspectionPortElement.getElementId());
-        assertEquals(inspectionPortElement.getEgressPort().getElementId(), portPairCheck.getEgressId());
-        assertEquals(inspectionPortElement.getEgressPort().getElementId(), portPairCheck.getEgressId());
-    }
-
-    private void assertPortPairGroupIsOk(PortPairElement inspectionPortElement) {
-        assertNotNull(inspectionPortElement.getPortPairGroup());
-        PortPairGroup ppgCheck = this.osClient.sfc().portpairgroups().get(inspectionPortElement.getParentId());
-        assertNotNull(ppgCheck);
-        assertNotNull(ppgCheck.getPortPairs());
-        assertTrue(ppgCheck.getPortPairs().contains(inspectionPortElement.getElementId()));
+       assertNotNull(this.api);
     }
 }

--- a/nsfc-plugin/src/test/java/org/osc/controller/nsfc/TestData.java
+++ b/nsfc-plugin/src/test/java/org/osc/controller/nsfc/TestData.java
@@ -50,8 +50,6 @@ class TestData {
 
     private static final String IADDR1_STR = "10.4.3.1";
 
-    private static final String EMAC2_STR = "ee:ff:aa:bb:cc:02";
-
     private static final String EMAC1_STR = "ee:ff:aa:bb:cc:01";
 
     private static final String IMAC1_STR = "ff:ff:aa:bb:cc:01";
@@ -83,7 +81,6 @@ class TestData {
     public static PortPairGroupService portPairGroupService;
     public static FlowClassifierService flowClassifierService;
 
-    @SuppressWarnings("unchecked")
     public static void setupDataObjects() {
         ingressPortElement = new NetworkElementImpl();
         ingressPortElement.setElementId(IMAC1_STR + IMAC1_STR);
@@ -138,8 +135,8 @@ class TestData {
         public T create(T object) {
             String id;
             do {
-				id = ID_GENERATOR.nextLong() + "";
-			} while (this.dataObjects.keySet().contains(id));
+                id = ID_GENERATOR.nextLong() + "";
+            } while (this.dataObjects.keySet().contains(id));
 
             object.setId(id);
             this.dataObjects.put(id, object);

--- a/nsfc-plugin/src/test/java/org/osc/controller/nsfc/TestData.java
+++ b/nsfc-plugin/src/test/java/org/osc/controller/nsfc/TestData.java
@@ -193,4 +193,7 @@ class TestData {
     private static class MockFlowClassifierService extends CRUDMockService<FlowClassifier> implements FlowClassifierService {
     }
 
+    static PortPairService mockPortPairService() {
+        return new MockPortPairService();
+    }
 }


### PR DESCRIPTION
* Integration tests pass with dummy sfc driver (not ovs)
* The driver is set in /etc/neutron/neutron.conf under [sfc] section.
* Use the line 'drivers = dummy' instead of 'drivers = ovs'.